### PR TITLE
Security precautions

### DIFF
--- a/packages/components/src/containers/EventCardsContainer.tsx
+++ b/packages/components/src/containers/EventCardsContainer.tsx
@@ -29,6 +29,9 @@ export const EventCardsContainer = React.memo(
   (props: EventCardsContainerProps) => {
     const { column } = props
 
+    const hasPrivateAccess = useReduxState(
+      selectors.githubHasPrivateAccessSelector,
+    )
     const subscription = useReduxState(
       state =>
         selectors.subscriptionSelector(state, column.subscriptionIds[0]) as
@@ -43,14 +46,17 @@ export const EventCardsContainer = React.memo(
     )
 
     const [filteredItems, setFilteredItems] = useState<EnhancedGitHubEvent[]>(
-      () => getFilteredEvents(data.items || [], column.filters),
+      () =>
+        getFilteredEvents(data.items || [], column.filters, hasPrivateAccess),
     )
 
     const canFetchMoreRef = useRef(false)
 
     useEffect(
       () => {
-        setFilteredItems(getFilteredEvents(data.items || [], column.filters))
+        setFilteredItems(
+          getFilteredEvents(data.items || [], column.filters, hasPrivateAccess),
+        )
       },
       [data, column.filters],
     )

--- a/packages/components/src/containers/NotificationCardsContainer.tsx
+++ b/packages/components/src/containers/NotificationCardsContainer.tsx
@@ -32,6 +32,9 @@ export const NotificationCardsContainer = React.memo(
   (props: NotificationCardsContainerProps) => {
     const { column } = props
 
+    const hasPrivateAccess = useReduxState(
+      selectors.githubHasPrivateAccessSelector,
+    )
     const subscription = useReduxState(
       state =>
         selectors.subscriptionSelector(
@@ -47,7 +50,11 @@ export const NotificationCardsContainer = React.memo(
     const [filteredItems, setFilteredItems] = useState<
       EnhancedGitHubNotification[]
     >(() =>
-      getFilteredNotifications(subscription.data.items || [], column.filters),
+      getFilteredNotifications(
+        subscription.data.items || [],
+        column.filters,
+        hasPrivateAccess,
+      ),
     )
 
     const canFetchMoreRef = useRef(false)
@@ -58,6 +65,7 @@ export const NotificationCardsContainer = React.memo(
           getFilteredNotifications(
             subscription.data.items || [],
             column.filters,
+            hasPrivateAccess,
           ),
         )
       },

--- a/packages/components/src/redux/actions/subscriptions.ts
+++ b/packages/components/src/redux/actions/subscriptions.ts
@@ -36,7 +36,7 @@ export function fetchSubscriptionSuccess(payload: {
 
 export function fetchSubscriptionFailure<E extends Error>(
   payload: { subscriptionId: string },
-  error: E,
+  error: E & { status?: number },
 ) {
   return createErrorActionWithPayload(
     'FETCH_SUBSCRIPTION_FAILURE',

--- a/packages/components/src/redux/sagas/subscriptions.ts
+++ b/packages/components/src/redux/sagas/subscriptions.ts
@@ -280,6 +280,20 @@ function* onFetchRequest(
   }
 }
 
+function* onFetchFailed(
+  action: ExtractActionFromActionCreator<
+    typeof actions.fetchSubscriptionFailure
+  >,
+) {
+  if (
+    action.error &&
+    action.error.status === 401 &&
+    action.error.message === 'Bad credentials'
+  ) {
+    yield put(actions.logout())
+  }
+}
+
 function onLogout() {
   if (notificationsCache) notificationsCache.clear()
 }
@@ -294,6 +308,7 @@ export function* subscriptionsSagas() {
     yield takeLatest('REPLACE_COLUMNS_AND_SUBSCRIPTIONS', cleanupSubscriptions),
     yield takeEvery('FETCH_COLUMN_SUBSCRIPTIONS', onFetchColumnSubscriptions),
     yield takeEvery('FETCH_SUBSCRIPTION_REQUEST', onFetchRequest),
+    yield takeEvery('FETCH_SUBSCRIPTION_FAILURE', onFetchFailed),
   ])
 }
 

--- a/packages/components/src/redux/sagas/subscriptions.ts
+++ b/packages/components/src/redux/sagas/subscriptions.ts
@@ -167,6 +167,7 @@ function* onFetchRequest(
 
   const subscription = selectors.subscriptionSelector(state, subscriptionId)
   const githubToken = selectors.githubTokenSelector(state)
+  const hasPrivateAccess = selectors.githubHasPrivateAccessSelector(state)
 
   const page = Math.max(1, _params.page || 1)
   const perPage = Math.min(_params.perPage || DEFAULT_PAGINATION_PER_PAGE, 50)
@@ -218,6 +219,7 @@ function* onFetchRequest(
         {
           cache: notificationsCache,
           githubToken,
+          hasPrivateAccess,
         },
       )
 

--- a/packages/components/src/redux/selectors/auth.ts
+++ b/packages/components/src/redux/selectors/auth.ts
@@ -11,6 +11,9 @@ export const appTokenSelector = (state: RootState) => s(state).appToken
 export const githubScopeSelector = (state: RootState) =>
   s(state).user && s(state).user!.github.scope
 
+export const githubHasPrivateAccessSelector = (state: RootState) =>
+  !!githubScopeSelector(state) && githubScopeSelector(state)!.includes('repo')
+
 export const githubTokenSelector = (state: RootState) =>
   s(state).user && s(state).user!.github.token
 

--- a/packages/components/src/screens/LoginScreen.tsx
+++ b/packages/components/src/screens/LoginScreen.tsx
@@ -192,8 +192,8 @@ export const LoginScreen = React.memo(() => {
 
     const githubScope =
       method === 'github.private'
-        ? ['user', 'repo', 'notifications', 'read:org']
-        : ['user', 'public_repo', 'notifications', 'read:org']
+        ? ['read:user', 'repo', 'notifications', 'read:org']
+        : ['read:user', 'public_repo', 'notifications', 'read:org']
 
     try {
       analytics.trackEvent('engagement', 'login', method, 1, { method })

--- a/packages/components/src/screens/LoginScreen.tsx
+++ b/packages/components/src/screens/LoginScreen.tsx
@@ -226,24 +226,24 @@ export const LoginScreen = React.memo(() => {
               loggingInMethod === 'github.public'
             }
             onPress={() => loginWithGitHub('github.public')}
-            rightIcon="globe"
+            // rightIcon="globe"
             style={styles.button}
-            subtitle="Public access"
+            subtitle="Public access only"
             title="Sign in with GitHub"
           />
 
-          <GitHubLoginButton
+          {/* <GitHubLoginButton
             analyticsLabel="github_login_private"
             loading={
               (isLoggingIn || isExecutingOAuth) &&
               loggingInMethod === 'github.private'
             }
             onPress={() => loginWithGitHub('github.private')}
-            rightIcon="lock"
+            // rightIcon="lock"
             style={styles.button}
             subtitle="Private access"
             title="Sign in with GitHub"
-          />
+          /> */}
 
           <Spacer height={contentPadding} />
 

--- a/packages/core/src/helpers/github/notifications.ts
+++ b/packages/core/src/helpers/github/notifications.ts
@@ -15,9 +15,11 @@ export async function getNotificationsEnhancementMap(
   {
     cache = new Map(),
     githubToken,
+    hasPrivateAccess,
   }: {
     cache: EnhancementCache | undefined | undefined
     githubToken: string
+    hasPrivateAccess: boolean
   },
 ): Promise<Record<string, NotificationPayloadEnhancement>> {
   const promises = notifications.map(async notification => {
@@ -31,6 +33,10 @@ export async function getNotificationsEnhancementMap(
     )
 
     const enhance: NotificationPayloadEnhancement = {}
+
+    const isPrivate = notification.repository.private
+    const hasAccess = !isPrivate || hasPrivateAccess
+    if (!hasAccess) return
 
     const hasSubjectCache = cache.has(notification.subject.url)
     const hasCommentCache = cache.has(notification.subject.latest_comment_url)


### PR DESCRIPTION
- Disable "Private Access" login button for now
- Disable privacy filter if user don't have private scope
- Instantly logout on Bad Credentials
- Ask for the minimum user permission with only read access (`read:user` instead of `user`)
- Only try fetching notification enhancement once, since it probably fail due to lack of permission