### PR TITLE
Make contributions easier

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 3000
+  onOpen: open-preview
+tasks:
+- init: yarn
+  command: yarn dev:web

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <span><a href="https://play.google.com/store/apps/details?id=com.devhubapp" target="_blank">Android</a>, <a href="https://itunes.apple.com/br/app/devhub-for-github/id1191864199?l=en&mt=8" target="_blank">iOS</a>, <a href="https://devhubapp.com/" target="_blank">Web</a> & <a href="https://github.com/devhubapp/devhub/releases" target="_self">Desktop</a> with <b>95%+ code sharing</b> between them<br/><i>thanks to React Native + React Native Web</i></span><br/>
   <a href="https://devhubapp.com/" target="_blank">devhubapp.com</a>
 </p>
-  
+
 [![DevHub Desktop](https://user-images.githubusercontent.com/619186/49800542-dfcee000-fd2e-11e8-8e08-ff95c5872513.png)](https://devhubapp.com/)
 
 
@@ -138,6 +138,10 @@ To open the mobile projects, use:
 - `yarn xcode`
 - `yarn studio`
 
+#### Contribute Online
+Alternatively, you can contribute using Gitpod, a free online dev environment for GitHub.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/devhubapp/devhub)
 <br/>
 
 ## Author


### PR DESCRIPTION
This PR lowers the barrier for contributers and generally allows tinkering with the code base easily using Gitpod, a free dev environment service for GitHub. I configured it so it runs 
 - `yarn` followed by 
 - `yarn dev:web` which will automatically open the web app in the preview. 

So people can immediately play around with the code and try out changes. Forking, committing and creating a PR is integrated as well.

Try: [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/c831d4c0-ab42-4107-baaa-09b5ab385f62)

<img width="1798" alt="screenshot 2019-01-09 at 15 17 45" src="https://user-images.githubusercontent.com/372735/50905963-56412980-1424-11e9-8192-51a2ce6432cf.png">

It could also support the [electron app through VNC](https://medium.com/gitpod/developing-native-ui-applications-in-gitpod-15af2967c24e) but I thought you would prefer keeping it simple. :)