### PR TITLE
Avoid sending ga event on focusing column

### DIFF
--- a/packages/components/src/screens/MainScreen.tsx
+++ b/packages/components/src/screens/MainScreen.tsx
@@ -313,9 +313,11 @@ export const MainScreen = React.memo(() => {
     [currentOpenedModal],
   )
 
-  if (!currentOpenedModal) {
-    analytics.trackScreenView('MAIN_SCREEN')
-  }
+  useEffect(() => {
+    if (!currentOpenedModal) {
+      analytics.trackScreenView('MAIN_SCREEN')
+    }
+  }, [currentOpenedModal])
 
   return (
     <Screen statusBarBackgroundThemeColor="header" useSafeArea={false}>


### PR DESCRIPTION
Hi!
I'm a big fan of devhub!
I think it has huge potential to change GitHub life!

I'm interested in improving performance especially around shortcut key.
I often use hjkl, 1~9 key, space and shift-space.

I've noticed MainScreen is re-rendered if `focusedColumnId` is changed:
https://github.com/devhubapp/devhub/blob/6aa24bb96658ce2541f69f9eccfc3d65826c726b/packages/components/src/screens/MainScreen.tsx#L49

It means `analytics.trackScreenView('MAIN_SCREEN')` is called every changing focused column.

### Before

![before](https://user-images.githubusercontent.com/1796864/56889861-a666f900-6ab2-11e9-9a28-68fd88481044.gif)

### After

![after](https://user-images.githubusercontent.com/1796864/56889864-aa931680-6ab2-11e9-9e9b-2043ed00e9ff.gif)
