### PR TITLE
Add unread dot on sidebar items

### DIFF
--- a/packages/components/src/components/columns/ColumnHeaderItem.tsx
+++ b/packages/components/src/components/columns/ColumnHeaderItem.tsx
@@ -33,6 +33,7 @@ import {
 import { TouchableOpacityProps } from '../common/TouchableOpacity'
 import { useTheme } from '../context/ThemeContext'
 import { getThemeColorOrItself } from '../themed/helpers'
+import { ThemedView } from '../themed/ThemedView'
 
 export interface ColumnHeaderItemProps {
   activeOpacity?: TouchableOpacityProps['activeOpacity']
@@ -62,6 +63,7 @@ export interface ColumnHeaderItemProps {
     | ((theme: ThemeColors) => string)
   iconName?: GitHubIcon
   iconStyle?: StyleProp<TextStyle>
+  isUnread?: boolean
   label?: string
   mainContainerStyle?: StyleProp<ViewStyle>
   noPadding?: boolean
@@ -99,6 +101,7 @@ export const ColumnHeaderItem = React.memo((props: ColumnHeaderItemProps) => {
     hoverForegroundThemeColor,
     iconName,
     iconStyle,
+    isUnread,
     label: _label,
     mainContainerStyle,
     noPadding,
@@ -313,6 +316,18 @@ export const ColumnHeaderItem = React.memo((props: ColumnHeaderItemProps) => {
                 marginRight: hasText ? contentPadding / 2 : 0,
               }}
             >
+              {isUnread && (
+                <ThemedView
+                  backgroundColor="primaryBackgroundColor"
+                  style={{
+                    position: 'absolute',
+                    right: contentPadding - (3 / 2) * size,
+                    width: 7,
+                    height: 7,
+                    borderRadius: 4,
+                  }}
+                />
+              )}
               {!!username ? (
                 <Avatar
                   isBot={false}


### PR DESCRIPTION
Related: #90

<img width="54" alt="Screen Shot 2019-06-26 at 10 38 14 PM" src="https://user-images.githubusercontent.com/30328854/60209375-2e734000-9863-11e9-8b29-909d5e831d8c.png">

> Web view

<img width="501" alt="Screen Shot 2019-06-26 at 10 38 32 PM" src="https://user-images.githubusercontent.com/30328854/60209373-2e734000-9863-11e9-839a-b9868cf3bfa7.png">

> Mobile view