### PR TITLE
an -> a

### DIFF
--- a/packages/core/src/helpers/github/events.ts
+++ b/packages/core/src/helpers/github/events.ts
@@ -364,7 +364,7 @@ export function getEventMetadata(
       case 'MemberEvent': {
         return {
           action: 'added',
-          actionText: `Added an user ${repositoryText &&
+          actionText: `Added a user ${repositoryText &&
             `to ${repositoryTextWithColon}`}`,
           subjectType: 'User',
         }


### PR DESCRIPTION
@brunolemos When a user is added to a repository, the event card said:

"... added an user to a repository ..."

instead of:

"... added a user to a repository ..."