### PR TITLE
Electron is added to the Tech Stack in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 - [Redux Saga](https://github.com/redux-saga/redux-saga/)
 - [Reselect](https://github.com/reduxjs/reselect)
 - [GraphQL](https://github.com/facebook/graphql)
-
+- [Electron](https://github.com/electron/electron)
 
 <br/>
 


### PR DESCRIPTION
Hi, nice job!
Looking for Desktop's platform name in the readme and I figured out it's missing from the Teck Stack. So, just in case the Electron's name should be there.