### PR TITLE
docs: update `brew` command to install cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ DevHub is a **mobile and desktop** app to help you **manage GitHub Notifications
   - Homebrew (macOS alternative):
     ```
       brew tap devhubapp/devhub
-      brew cask install devhub
+      brew install --cask devhub
     ```
 
 <br/>


### PR DESCRIPTION
Brew casks are now installed using the flag `--cask`.

https://github.com/Homebrew/brew/blob/a81a76b196e987210a0f1f2dcfe8453483a23549/docs/Manpage.md#L305-L306