### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/landing/src/components/sections/pricing/PricingPlanBlock.tsx
+++ b/landing/src/components/sections/pricing/PricingPlanBlock.tsx
@@ -83,7 +83,7 @@ export function PricingPlanBlock(props: PricingPlanBlockProps) {
 
   const priceLabelCents =
     _priceLabel[_priceLabel.length - 3] === '.'
-      ? _priceLabel.substr(-3)
+      ? _priceLabel.slice(-3)
       : undefined
   const priceLabelWithoutCents =
     priceLabelCents && _priceLabel.endsWith(priceLabelCents)

--- a/packages/components/src/components/cards/BaseCard.shared.ts
+++ b/packages/components/src/components/cards/BaseCard.shared.ts
@@ -311,8 +311,8 @@ function _getCardPropsForItem(
         actionTextOptions,
       )
       const actionText = `${_actionText
-        .substr(0, 1)
-        .toLowerCase()}${_actionText.substr(1)}`
+        .slice(0, 1)
+        .toLowerCase()}${_actionText.slice(1)}`
 
       const iconDetails = getEventIconAndColor(event)
       const icon = iconDetails as IconProp
@@ -1330,8 +1330,8 @@ export function getCardPushNotificationItem(
       } = getEventMetadata(event, actionTextOptions)
 
       const actionText = `${_actionText
-        .substr(0, 1)
-        .toLowerCase()}${_actionText.substr(1)}`
+        .slice(0, 1)
+        .toLowerCase()}${_actionText.slice(1)}`
 
       const actorUsername = actor.display_login || actor.login
 

--- a/packages/components/src/components/modals/partials/PricingPlanBlock.tsx
+++ b/packages/components/src/components/modals/partials/PricingPlanBlock.tsx
@@ -98,7 +98,7 @@ export function PricingPlanBlock(props: PricingPlanBlockProps) {
       : _priceLabel
   const priceLabelCents =
     _cents && _priceLabel.endsWith(_cents.toString())
-      ? _priceLabel.substr(-3)
+      ? _priceLabel.slice(-3)
       : ''
 
   let footerText = ''

--- a/packages/components/src/libs/analytics/index.web.ts
+++ b/packages/components/src/libs/analytics/index.web.ts
@@ -25,7 +25,7 @@ export const analytics: Analytics = {
     ga('send', 'event', {
       eventCategory: hideTokenFromString(category),
       eventAction: hideTokenFromString(action),
-      eventLabel: hideTokenFromString(label || '')!.substr(0, 100),
+      eventLabel: hideTokenFromString(label || '')!.slice(0, 100),
       eventValue: value,
     })
   },

--- a/packages/components/src/libs/analytics/native.ts
+++ b/packages/components/src/libs/analytics/native.ts
@@ -22,7 +22,7 @@ export const analytics: Analytics = {
       .analytics()
       .logEvent(hideTokenFromString(action || '').replace(/\//g, '_'), {
         event_category: hideTokenFromString(category),
-        event_label: hideTokenFromString(label || '').substr(0, 100),
+        event_label: hideTokenFromString(label || '').slice(0, 100),
         value,
       })
   },

--- a/packages/core/src/helpers/github/notifications.ts
+++ b/packages/core/src/helpers/github/notifications.ts
@@ -364,7 +364,7 @@ export async function getNotificationsEnhancementMap(
     const commentCache = cache.get(notification.subject.latest_comment_url)
 
     const subjectField = (notification.subject.type[0].toLowerCase() +
-      notification.subject.type.substr(
+      notification.subject.type.slice(
         1,
       )) as keyof NotificationPayloadEnhancement
 

--- a/packages/core/src/helpers/github/url.ts
+++ b/packages/core/src/helpers/github/url.ts
@@ -51,7 +51,7 @@ export function getCommitCompareUrlFromUrls(
   const sha2 = getCommitShaFromUrl(commit2URL)
   if (!(sha1 && sha2)) return
 
-  return `${repo1URL}/compare/${sha1.substr(0, 7)}...${sha2.substr(0, 7)}`
+  return `${repo1URL}/compare/${sha1.slice(0, 7)}...${sha2.slice(0, 7)}`
 }
 
 export function getCommitCompareUrlFromRefs(
@@ -61,7 +61,7 @@ export function getCommitCompareUrlFromRefs(
 ): string | undefined {
   if (!(before && head && repoURL)) return
 
-  return `${repoURL}/compare/${before.substr(0, 7)}...${head.substr(0, 7)}`
+  return `${repoURL}/compare/${before.slice(0, 7)}...${head.slice(0, 7)}`
 }
 
 export function getIssueOrPullRequestNumberFromUrl(

--- a/packages/core/src/helpers/shared.ts
+++ b/packages/core/src/helpers/shared.ts
@@ -179,7 +179,7 @@ export function trimNewLinesAndSpaces(text?: string, maxLength = 120) {
 
   let newText = text.replace(/\s+/g, ' ').trim()
   if (maxLength > 0 && newText.length > maxLength) {
-    newText = `${newText.substr(0, maxLength).trim()}...`
+    newText = `${newText.slice(0, maxLength).trim()}...`
   }
 
   return newText

--- a/subdomains/www/src/index.js
+++ b/subdomains/www/src/index.js
@@ -1,6 +1,6 @@
 module.exports = (req, res) => {
   res.statusCode = 301
-  res.setHeader('Location', `https://devhubapp.com/${req.url.substr(1)}`)
+  res.setHeader('Location', `https://devhubapp.com/${req.url.slice(1)}`)
 
   res.end()
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.